### PR TITLE
Fixing slider overflow, for narrower window size

### DIFF
--- a/style.css
+++ b/style.css
@@ -287,6 +287,7 @@ footer {
 
     .parent {
         margin-top: -65px;
+        min-width: 70%;
     }
 }
 


### PR DESCRIPTION
Hi there, I'm used to having narrower windows and I noticed the slider overflowing, felt like it would be nicer to have it fixed.

# Window width - 720px

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/7468a60b-ba1e-420d-89ef-b8f5be163f29) | ![After](https://github.com/user-attachments/assets/fad998ec-133f-4062-8d69-4a2f6e016b69) |